### PR TITLE
update package.json and craco.config.js

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,13 +1,21 @@
 module.exports = {
     webpack: {
-        configure:{
-            // See https://github.com/webpack/webpack/issues/6725
-            module:{
-                rules: [{
-                    test: /\.wasm$/,
-                    type: 'javascript/auto',
-                }]
-            }
-        }
-    }
-};
+      configure: (webpackConfig) => {
+        // Add the following lines to handle 'crypto' and 'fs' dependencies
+        webpackConfig.resolve.fallback = {
+          fs: require.resolve("browserify-fs"), // or 'empty' if you prefer an empty module
+          crypto: require.resolve('crypto-browserify'),
+          stream: require.resolve('stream-browserify'),
+        };
+  
+        // Add the 'module' configuration for handling .wasm files
+        webpackConfig.module.rules.push({
+          test: /\.wasm$/,
+          type: 'javascript/auto',
+        });
+  
+        return webpackConfig;
+      },
+    },
+  };
+  

--- a/package.json
+++ b/package.json
@@ -9,12 +9,17 @@
   "main": "src/index.js",
   "license": "MIT",
   "dependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "browserify-fs": "^1.0.0",
+    "crypto-browserify": "^3.12.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "sql.js": "^1.6.2"
+    "sql.js": "^1.6.2",
+    "stream-browserify": "^3.0.0"
   },
   "devDependencies": {
     "@craco/craco": "^5.9.0",
+    "react-scripts": "^5.0.1",
     "typescript": "^4.5.5"
   },
   "scripts": {


### PR DESCRIPTION
- added the following dependencies: 
"@babel/plugin-proposal-private-property-in-object": "^7.21.11", 
"browserify-fs": "^1.0.0",
"crypto-browserify": "^3.12.0",
"react-scripts": "^5.0.1",

- added fallbacks to the webpackConfig:
fs: require.resolve("browserify-fs"), // or 'empty' if you prefer an empty module
crypto: require.resolve('crypto-browserify'),
stream: require.resolve('stream-browserify'),

- project will now build and start.